### PR TITLE
Add empty raw data folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Ignore the raw data folder
+data/raw/
+
+# Ignore venvs
 venv/
 .venv/
 env/

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This is an [SSI Collaborations Workshop 2022](https://software.ac.uk/cw22) hack 
 ├─ code/                     
 │  ├─ data-retrieval/        Code/software for data retrieval from GitHub
 ├─ data/                     The data we analyse
-│  ├─ raw/                   Raw data retrieved via the GitHub Search API
-│  │  ├─ <name>/             Directories holding the raw data retrieved by different people
+│  ├─ raw/                   NEVER MAKE THIS PUBLIC! DATA PRIVACY!
+├─ output/
+│  ├─ figures/               Figures for the presentation
 ```
 
 

--- a/data/raw/DO_NOT_PUSH_THIS.md
+++ b/data/raw/DO_NOT_PUSH_THIS.md
@@ -1,0 +1,3 @@
+# For data privacy reasons, this folder should never be pushed to a publi repository!
+
+It is for intermittent provision of raw CFF files.


### PR DESCRIPTION
PR adds an empty raw data folder with a warning file that can be used as target for link resolution and keeping CFF files intermittently.