### PR TITLE
Add pyyaml dependency to pyproject.toml

### DIFF
--- a/code/analysis/python/pyproject.toml
+++ b/code/analysis/python/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Stephan Druskat <stephan.druskat@dlr.de>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
+PyYAML = "^6.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
The `read_cff_files` function uses the `yaml` module, but we've not specified this as a dependency yet.