### PR TITLE
Use cffconvert directly via subprocess to validate

### DIFF
--- a/code/analysis/python/pyproject.toml
+++ b/code/analysis/python/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Stephan Druskat <stephan.druskat@dlr.de>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 PyYAML = "^6.0"
+cffconvert = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/code/analysis/python/python/read_cff_files.py
+++ b/code/analysis/python/python/read_cff_files.py
@@ -2,6 +2,12 @@
 import os
 import yaml
 import argparse
+import subprocess
+
+
+def validate(infile):
+    output = subprocess.check_output(['cffconvert', '--validate', '-i', infile])
+    return 'Citation metadata are valid according to schema version' in output
 
 
 def sanity_check(cff_file: dict) -> bool:
@@ -30,7 +36,7 @@ def read_cff_files(datadir: str):
                 # invalid YAML list
                 try:
                     cff_file = yaml.safe_load(f)
-                    if sanity_check(cff_file):
+                    if validate(datadir + '/' + file):
                         _cff_data.append(cff_file)
                     else:
                         # Invalid CFF, but valid YAML


### PR DESCRIPTION
Uses cffconvert directly in a subprocess for validation.